### PR TITLE
fix: handle slackbot launch in isolated automation env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
@@ -27,7 +27,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.7
+    rev: v0.15.2
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: Slack
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -1699,7 +1699,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* handle slackbot launch in isolated automation env

--- a/slack.json
+++ b/slack.json
@@ -13,7 +13,7 @@
     ],
     "package_name": "phantom_slack",
     "type": "information",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "main_module": "slack_connector.py",
     "app_version": "2.10.0",
     "utctime_updated": "2025-12-10T10:07:47.036106Z",

--- a/slack_bot.py
+++ b/slack_bot.py
@@ -1,6 +1,6 @@
 # File: slack_bot.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/slack_connector.py
+++ b/slack_connector.py
@@ -1,6 +1,6 @@
 # File: slack_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -1299,9 +1300,29 @@ class SlackConnector(phantom.BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, SLACK_SOCKET_TOKEN_ERROR)
 
         self.save_progress("Starting SlackBot")
-        proc = subprocess.Popen(["phenv", "python3", slack_bot_filename, asset_id, app_version, app_id])
-        self._state["pid"] = proc.pid
-        self.save_progress(f"Started SlackBot with pid: {proc.pid}")
+
+        phenv_path = shutil.which("phenv")
+
+        if phenv_path:
+            cmd = [phenv_path, "python3", slack_bot_filename, asset_id, app_version, app_id]
+            self.save_progress("Using phenv wrapper")
+        else:
+            # Isolated automation broker: use direct Python path from environment variable
+            python313_location = os.environ.get("PYTHON313_LOCATION", "/opt/phantom/usr/python313")
+            py3 = os.path.join(python313_location, "bin", "python3")
+
+            if not os.path.isfile(py3):
+                return action_result.set_status(phantom.APP_ERROR, f"Python executable not found at: {py3}")
+
+            cmd = [py3, slack_bot_filename, asset_id, app_version, app_id]
+            self.save_progress(f"phenv not available, using direct Python path: {py3}")
+
+        try:
+            proc = subprocess.Popen(cmd)
+            self._state["pid"] = proc.pid
+            self.save_progress(f"Started SlackBot with pid: {proc.pid}")
+        except Exception as e:
+            return action_result.set_status(phantom.APP_ERROR, f"Failed to start SlackBot: {self._get_error_message_from_exception(e)}")
 
         return action_result.set_status(phantom.APP_SUCCESS, SLACK_SUCCESSFULLY_SLACKBOT_STARTED)
 

--- a/slack_consts.py
+++ b/slack_consts.py
@@ -1,6 +1,6 @@
 # File: slack_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
phenv is not available when actions are run inside automation broker. This change is to use py3 when phenv is unavailable.